### PR TITLE
Fix compile error in ipsniffer

### DIFF
--- a/ipsniffer/src/main.rs
+++ b/ipsniffer/src/main.rs
@@ -1,5 +1,8 @@
-std::env;
+use std::env;
 
+/// Simple program that prints all environment variables.
 fn main() {
-    
-}:
+    for (key, value) in env::vars() {
+        println!("{key}={value}");
+    }
+}


### PR DESCRIPTION
## Summary
- fix syntax in `ipsniffer`'s `main.rs`
- add a minimal implementation that prints environment variables

## Testing
- `cargo build --quiet` in `ipsniffer`
- `cargo test --quiet` in `ipsniffer`
- `cargo test --quiet` in `minigrep`
- `cargo test --quiet` in `Leetcodes/binary_search_704`
- `cargo test --quiet` in `Leetcodes/search_insert_position_35`
- `cargo build --quiet` in `rust-next-blog` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fc524d98c8320a1a7c698d09a8532